### PR TITLE
Remove reference to deprecated openmp package. Use llvm-openmp instead.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,6 +18,7 @@ bld.bat text eol=crlf
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
 .scripts/* linguist-generated=true
+.woodpecker.yml linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ conda search graphblas --channel conda-forge
 About conda-forge
 =================
 
-[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
+[![Powered by
+NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org)
 
 conda-forge is a community-led conda channel of installable packages.
 In order to provide high-quality builds, the process has been automated into the

--- a/build-locally.py
+++ b/build-locally.py
@@ -22,6 +22,10 @@ def setup_environment(ns):
         os.environ["MINIFORGE_HOME"] = os.path.join(
             os.path.dirname(__file__), "miniforge3"
         )
+    if "OSX_SDK_DIR" not in os.environ:
+        os.environ["OSX_SDK_DIR"] = os.path.join(
+            os.path.dirname(__file__), "SDKs"
+        )
 
 
 def run_docker_build(ns):

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: dc0090cdc99b509ba54d47e22833b7adaf35af0dfcef357d8ef38e1fa4e66b65
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("graphblas", max_pin='x.x') }}
 
@@ -21,11 +21,9 @@ requirements:
     - make
     - m4  # [not win]
   host:
-    - openmp  # [linux]
-    - llvm-openmp  # [osx]
+    - llvm-openmp
   run:
-    - openmp  # [linux]
-    - llvm-openmp  # [osx]
+    - llvm-openmp
 
 test:
   commands:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

The `openmp` package appears to be deprecated and has not been updated since version 8. Other packages have switched to `llvm-openmp`, so do the same. This allows us to build against LLVM 12.

Also this avoids confusing conflicts caused by the fact that this package effectively required LLVM 8, but other packages require recent LLVM versions. The result was that if graphblas was installed many packages would be forced to very old versions.

<!--
Please add any other relevant info below:
-->
