### PR TITLE
Update to v8.0.2

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,6 +10,7 @@ cmake -G "NMake Makefiles" ^
       -D CMAKE_BUILD_TYPE=Release ^
       -D BUILD_SHARED_LIBS=ON ^
       -D GBNCPUFEAT=ON ^
+      -D JITINIT=2 ^
       %SRC_DIR%
 if errorlevel 1 exit /b 1
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,7 +2,8 @@
 
 # make sure CMake install goes in the right place
 export INSTALL="${PREFIX}"
-export CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=Release"
+# Use JITINIT=2 (=run) to use pre-JIT kernels that don't need a compiler at runtime
+export CMAKE_OPTIONS="-DCMAKE_INSTALL_PREFIX=${PREFIX} -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=Release -DJITINIT=2"
 if [[ "$OSTYPE" != "linux"* ]]; then
   export CMAKE_OPTIONS="-DGBNCPUFEAT=1 ${CMAKE_OPTIONS}"
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "8.0.1" %}
+{% set version = "8.0.2" %}
 
 package:
   name: graphblas
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://github.com/DrTimothyAldenDavis/GraphBLAS/archive/v{{ version }}.tar.gz
-  sha256: c4aed43cf5a60ea8c17d2981028ff1355679c31c65050cff93aa07b493178be9
+  sha256: cedecdcff130c3b7e5d571b693dc2c28bc96ef5f09b33e52f0bcd42b23593ea0
 
 build:
   number: 0


### PR DESCRIPTION
Also, disable the JIT by default by setting it to 2 (i.e., "run"), which will still run pre-JIT kernels that don't need a compiler at runtime. The JIT may still be re-enabled and used at runtime.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
